### PR TITLE
update image to v2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Modify the file and change `replicas` from 3 to 5.
         memory: "1Gi"
     replicas: 5
     image: vesoft/nebula-storaged
-    version: v2.6.1
+    version: v2.6.2
     storageClaim:
       resources:
         requests:
@@ -102,7 +102,7 @@ Similarly we can decrease the size of the cluster from 5 back to 3 by changing t
         memory: "1Gi"
     replicas: 3
     image: vesoft/nebula-storaged
-    version: v2.6.1
+    version: v2.6.2
     storageClaim:
       resources:
         requests:
@@ -147,7 +147,7 @@ $ kubectl get pods -l app.kubernetes.io/cluster=nebula  -o jsonpath="{.items[*].
       3 vesoft/nebula-storaged:v2.5.1
 ```
 
-Now modify the file `apps_v1alpha1_nebulacluster.yaml` and change the `version` from v2.5.1 to v2.6.1:
+Now modify the file `apps_v1alpha1_nebulacluster.yaml` and change the `version` from v2.5.1 to v2.6.2:
 
 Apply the version change to the cluster CR:
 
@@ -155,13 +155,13 @@ Apply the version change to the cluster CR:
 $ kubectl apply -f config/samples/apps_v1alpha1_nebulacluster.yaml
 ```
 
-Wait 2 minutes. The container image version should be updated to v2.6.1:
+Wait 2 minutes. The container image version should be updated to v2.6.2:
 
 ```
 $ kubectl get pods -l app.kubernetes.io/cluster=nebula  -o jsonpath="{.items[*].spec.containers[*].image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
-      1 vesoft/nebula-graphd:v2.6.1
-      1 vesoft/nebula-metad:v2.6.1
-      3 vesoft/nebula-storaged:v2.6.1
+      1 vesoft/nebula-graphd:v2.6.2
+      1 vesoft/nebula-metad:v2.6.2
+      3 vesoft/nebula-storaged:v2.6.2
 ```
 
 ### Failover

--- a/charts/nebula-cluster/values.yaml
+++ b/charts/nebula-cluster/values.yaml
@@ -1,5 +1,5 @@
 nebula:
-  version: v2.6.1
+  version: v2.6.2
   imagePullPolicy: Always
   storageClassName: ""
   schedulerName: default-scheduler # nebula-scheduler

--- a/config/samples/apps_v1alpha1_nebulacluster.yaml
+++ b/config/samples/apps_v1alpha1_nebulacluster.yaml
@@ -13,7 +13,7 @@ spec:
         memory: "1Gi"
     replicas: 1
     image: vesoft/nebula-graphd
-    version: v2.6.1
+    version: v2.6.2
     service:
       type: NodePort
       externalTrafficPolicy: Local
@@ -32,7 +32,7 @@ spec:
         memory: "1Gi"
     replicas: 1
     image: vesoft/nebula-metad
-    version: v2.6.1
+    version: v2.6.2
     dataVolumeClaim:
       resources:
         requests:
@@ -53,7 +53,7 @@ spec:
         memory: "1Gi"
     replicas: 3
     image: vesoft/nebula-storaged
-    version: v2.6.1
+    version: v2.6.2
     dataVolumeClaim:
       resources:
         requests:

--- a/doc/user/custom_config.md
+++ b/doc/user/custom_config.md
@@ -24,7 +24,7 @@ spec:
         memory: "1Gi"
     replicas: 1
     image: vesoft/nebula-graphd
-    version: v2.6.1
+    version: v2.6.2
     storageClaim:
       resources:
         requests:

--- a/doc/user/nebula_cluster_helm_guide.md
+++ b/doc/user/nebula_cluster_helm_guide.md
@@ -75,7 +75,7 @@ The following table lists is the configurable parameters of the chart and their 
 | Parameter | Description | Default |
 |:---------|:-----------|:-------|
 | `nameOverride` | Override the name of the chart | `nil` |
-| `nebula.version` | Nebula version | `v2.6.1` |
+| `nebula.version` | Nebula version | `v2.6.2` |
 | `nebula.imagePullPolicy` | Nebula image pull policy | `Always` |
 | `nebula.storageClassName` | PersistentVolume class, default to use the default StorageClass | `nil` |
 | `nebula.schedulerName` | Scheduler for nebula component | `default-scheduler` |

--- a/pkg/controller/nebulacluster/nebula_cluster_control_test.go
+++ b/pkg/controller/nebulacluster/nebula_cluster_control_test.go
@@ -172,7 +172,7 @@ func newNebulaCluster() *v1alpha1.NebulaCluster {
 						},
 					},
 					Image:   "vesoft/graphd",
-					Version: "v2.6.1",
+					Version: "v2.6.2",
 				},
 			},
 			Metad: &v1alpha1.MetadSpec{
@@ -185,7 +185,7 @@ func newNebulaCluster() *v1alpha1.NebulaCluster {
 						},
 					},
 					Image:   "vesoft/metad",
-					Version: "v2.6.1",
+					Version: "v2.6.2",
 				},
 			},
 			Storaged: &v1alpha1.StoragedSpec{
@@ -198,7 +198,7 @@ func newNebulaCluster() *v1alpha1.NebulaCluster {
 						},
 					},
 					Image:   "vesoft/storaged",
-					Version: "v2.6.1",
+					Version: "v2.6.2",
 				},
 			},
 		},


### PR DESCRIPTION
v2.6.1 will suffer from graphd crashing when host OS is in cgroupv2.