### PR TITLE
Increase kube-scheduler memory

### DIFF
--- a/charts/nebula-operator/templates/scheduler-deployment.yaml
+++ b/charts/nebula-operator/templates/scheduler-deployment.yaml
@@ -54,10 +54,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 30Mi
+              memory: 60Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 40Mi
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
When I was using the operator (as a helm chart), I was getting OOMKilled for the `kube-scheduler` container. Doubling it seems to have resolved the crashes.