### PR TITLE
mod: rebranding name of Nebula Graph as NebulaGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nebula Operator
 
-Nebula Operator manages [NebulaGraph](https://github.com/vesoft-inc/nebula-graph) clusters on [Kubernetes](https://kubernetes.io) and automates tasks related to operating a NebulaGraph cluster. 
+Nebula Operator manages [NebulaGraph](https://github.com/vesoft-inc/nebula) clusters on [Kubernetes](https://kubernetes.io) and automates tasks related to operating a NebulaGraph cluster.
 It evolved from [NebulaGraph Cloud Service](https://www.nebula-cloud.io/), makes NebulaGraph a truly cloud-native database.
 
 ## Quick Start
@@ -35,7 +35,7 @@ $ kubectl create -f config/samples/graphd-nodeport-service.yaml
 # nebula-console -u user -p password --address=192.168.8.26 --port=32236
 2021/04/15 16:50:23 [INFO] connection pool is initialized successfully
 
-Welcome to Nebula Graph!
+Welcome to NebulaGraph!
 (user@nebula) [(none)]> 
 ```
 

--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -20,8 +20,7 @@ entries:
         name: Kevin Qiao
     name: nebula-cluster
     sources:
-      - https://github.com/vesoft-inc/nebula-graph
-      - https://github.com/vesoft-inc/nebula-storage
+      - https://github.com/vesoft-inc/nebula
       - https://github.com/vesoft-inc/nebula-operator
     urls:
       - https://github.com/vesoft-inc/nebula-operator/releases/download/v1.2.0/nebula-cluster-1.2.0.tgz
@@ -45,8 +44,7 @@ entries:
         name: Kevin Qiao
     name: nebula-cluster
     sources:
-      - https://github.com/vesoft-inc/nebula-graph
-      - https://github.com/vesoft-inc/nebula-storage
+      - https://github.com/vesoft-inc/nebula
       - https://github.com/vesoft-inc/nebula-operator
     urls:
       - https://github.com/vesoft-inc/nebula-operator/releases/download/v1.1.0/nebula-cluster-1.1.0.tgz
@@ -70,8 +68,7 @@ entries:
         name: Kevin Qiao
     name: nebula-cluster
     sources:
-      - https://github.com/vesoft-inc/nebula-graph
-      - https://github.com/vesoft-inc/nebula-storage
+      - https://github.com/vesoft-inc/nebula
       - https://github.com/vesoft-inc/nebula-operator
     urls:
       - https://github.com/vesoft-inc/nebula-operator/releases/download/v1.0.0/nebula-cluster-1.0.0.tgz
@@ -95,8 +92,7 @@ entries:
       name: Kevin Qiao
     name: nebula-cluster
     sources:
-    - https://github.com/vesoft-inc/nebula-graph
-    - https://github.com/vesoft-inc/nebula-storage
+    - https://github.com/vesoft-inc/nebula
     - https://github.com/vesoft-inc/nebula-operator
     urls:
     - https://github.com/vesoft-inc/nebula-operator/releases/download/v0.9.0/nebula-cluster-0.9.0.tgz
@@ -120,8 +116,7 @@ entries:
       name: Kevin Qiao
     name: nebula-cluster
     sources:
-    - https://github.com/vesoft-inc/nebula-graph
-    - https://github.com/vesoft-inc/nebula-storage
+    - https://github.com/vesoft-inc/nebula
     - https://github.com/vesoft-inc/nebula-operator
     urls:
     - https://vesoft-inc.github.io/nebula-operator/charts/nebula-cluster-0.8.0.tgz

--- a/charts/nebula-cluster/Chart.yaml
+++ b/charts/nebula-cluster/Chart.yaml
@@ -5,8 +5,7 @@ version: 0.1.0
 appVersion: 1.0.0
 home: https://nebula-graph.io
 sources:
-- https://github.com/vesoft-inc/nebula-graph
-- https://github.com/vesoft-inc/nebula-storage
+- https://github.com/vesoft-inc/nebula
 - https://github.com/vesoft-inc/nebula-operator
 keywords:
   - kubernetes

--- a/doc/user/balance.md
+++ b/doc/user/balance.md
@@ -10,4 +10,4 @@ We provide a parameter `enableAutoBalance` in crd to control whether to automati
 
 Through both stages, the scaling process of the controller replicas is decoupled from the balancing data process and user executing it at low traffic. 
 
-Such an implementation can effectively reduce the impact of data migration on online services, which is in line with the Nebula Graph principle: Balancing data is not fully automated and when to balance data is decided by users.
+Such an implementation can effectively reduce the impact of data migration on online services, which is in line with the NebulaGraph principle: Balancing data is not fully automated and when to balance data is decided by users.

--- a/doc/user/client_service.md
+++ b/doc/user/client_service.md
@@ -19,7 +19,7 @@ $ kubectl run --rm -ti --image vesoft/nebula-console:v2.5.0 --restart=Never -- /
 / # nebula-console -u user -p password --address=nebula-graphd-svc --port=9669
 2021/04/12 08:16:30 [INFO] connection pool is initialized successfully
 
-Welcome to Nebula Graph!
+Welcome to NebulaGraph!
 (user@nebula) [(none)]> 
 ```
 
@@ -83,7 +83,7 @@ Now test the connection outside the Kubernetes cluster:
 / # nebula-console -u user -p password --address=192.168.8.26 --port=32236
 2021/04/12 08:50:32 [INFO] connection pool is initialized successfully
 
-Welcome to Nebula Graph!
+Welcome to NebulaGraph!
 (user@nebula) [(none)]> 
 ```
 
@@ -114,7 +114,7 @@ If ConfigMap tcp-services is configured, then test the connection outside the Ku
 / # nebula-console -addr 192.168.8.25 -port 9669 -u root -p nebula
 2021/11/08 14:53:56 [INFO] connection pool is initialized successfully
 
-Welcome to Nebula Graph!
+Welcome to NebulaGraph!
 
 (root@nebula) [(none)]> 
 ```

--- a/doc/user/ngctl_guide.md
+++ b/doc/user/ngctl_guide.md
@@ -1,6 +1,6 @@
 
 # Overview
-ngctl is a terminal cmd tool for Nebula Graph managed by nebula-operator, it has the following commands:
+ngctl is a terminal cmd tool for NebulaGraph managed by nebula-operator, it has the following commands:
 - [ngctl use](#ngctl-use)
 - [ngctl console](#ngctl-console)
 - [ngctl list](#ngctl-list)

--- a/pkg/ngctl/cmd/console/console.go
+++ b/pkg/ngctl/cmd/console/console.go
@@ -106,8 +106,8 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("image-pull-policy", "",
 		"The image pull policy for the container."+
 			" If left empty, this value will not be specified by the client and defaulted by the server.")
-	cmd.Flags().StringVarP(&o.User, "user", "u", o.User, "The Nebula Graph login user name.")
-	cmd.Flags().StringVarP(&o.Password, "password", "p", o.Password, "The Nebula Graph login password.")
+	cmd.Flags().StringVarP(&o.User, "user", "u", o.User, "The NebulaGraph login user name.")
+	cmd.Flags().StringVarP(&o.Password, "password", "p", o.Password, "The NebulaGraph login password.")
 }
 
 // Complete completes all the required options
@@ -149,11 +149,11 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 	}
 
 	if o.User == "" {
-		return fmt.Errorf("the Nebula Graph login user name cannot be empty")
+		return fmt.Errorf("the NebulaGraph login user name cannot be empty")
 	}
 
 	if o.Password == "" {
-		return fmt.Errorf("the Nebula Graph login password cannot be empty")
+		return fmt.Errorf("the NebulaGraph login password cannot be empty")
 	}
 
 	return nil


### PR DESCRIPTION
mod: rebranding name of Nebula Graph as NebulaGraph

and change `https://github.com/vesoft-inc/nebula-graph` to `https://github.com/vesoft-inc/nebula`.