### PR TITLE
separate flags into dynamic and static

### DIFF
--- a/apis/pkg/annotation/annotation.go
+++ b/apis/pkg/annotation/annotation.go
@@ -26,8 +26,10 @@ const (
 	AnnLastSyncTimestampKey = "nebula-graph.io/sync-timestamp"
 	// AnnHaModeKey is annotation key to indicate whether in ha mode
 	AnnHaModeKey = "nebula-graph.io/ha-mode"
-	// AnnLastAppliedFlagsKey is annotation key to indicate the last applied custom flags
-	AnnLastAppliedFlagsKey = "nebula-graph.io/last-applied-flags"
+	// AnnLastAppliedDynamicFlagsKey is annotation key to indicate the last applied custom dynamic flags
+	AnnLastAppliedDynamicFlagsKey = "nebula-graph.io/last-applied-dynamic-flags"
+	// AnnLastAppliedStaticFlagsKey is annotation key to indicate the last applied custom static flags
+	AnnLastAppliedStaticFlagsKey = "nebula-graph.io/last-applied-static-flags"
 	// AnnLastAppliedConfigKey is annotation key to indicate the last applied configuration
 	AnnLastAppliedConfigKey = "nebula-graph.io/last-applied-configuration"
 	// AnnPodSchedulingKey is pod scheduling annotation key, it represents whether the pod is scheduling

--- a/pkg/controller/component/graphd_cluster.go
+++ b/pkg/controller/component/graphd_cluster.go
@@ -80,7 +80,7 @@ func (c *graphdCluster) syncGraphdWorkload(nc *v1alpha1.NebulaCluster) error {
 	notExist := apierrors.IsNotFound(err)
 	oldWorkload := oldWorkloadTemp.DeepCopy()
 
-	cm, cmHash, e, err := c.syncGraphdConfigMap(nc.DeepCopy())
+	cm, cmHash, err := c.syncGraphdConfigMap(nc.DeepCopy())
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (c *graphdCluster) syncGraphdWorkload(nc *v1alpha1.NebulaCluster) error {
 
 	if nc.GraphdComponent().IsReady() {
 		endpoints := nc.GetGraphdEndpoints(v1alpha1.GraphdPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations(), e); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update graphd cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 	}
@@ -171,7 +171,7 @@ func (c *graphdCluster) syncGraphdService(nc *v1alpha1.NebulaCluster) error {
 	return syncService(newSvc, c.clientSet.Service())
 }
 
-func (c *graphdCluster) syncGraphdConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, bool, error) {
+func (c *graphdCluster) syncGraphdConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, error) {
 	return syncConfigMap(
 		nc.GraphdComponent(),
 		c.clientSet.ConfigMap(),

--- a/pkg/controller/component/metad_cluster.go
+++ b/pkg/controller/component/metad_cluster.go
@@ -92,7 +92,7 @@ func (c *metadCluster) syncMetadWorkload(nc *v1alpha1.NebulaCluster) error {
 	notExist := apierrors.IsNotFound(err)
 	oldWorkload := oldWorkloadTemp.DeepCopy()
 
-	cm, cmHash, e, err := c.syncMetadConfigMap(nc.DeepCopy())
+	cm, cmHash, err := c.syncMetadConfigMap(nc.DeepCopy())
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (c *metadCluster) syncMetadWorkload(nc *v1alpha1.NebulaCluster) error {
 		}
 
 		endpoints := nc.GetMetadEndpoints(v1alpha1.MetadPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations(), e); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update metad cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 	}
@@ -165,7 +165,7 @@ func (c *metadCluster) syncNebulaClusterStatus(nc *v1alpha1.NebulaCluster, oldWo
 	return syncComponentStatus(nc.MetadComponent(), &nc.Status.Metad, oldWorkload)
 }
 
-func (c *metadCluster) syncMetadConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, bool, error) {
+func (c *metadCluster) syncMetadConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, error) {
 	return syncConfigMap(
 		nc.MetadComponent(),
 		c.clientSet.ConfigMap(),

--- a/pkg/controller/component/storaged_cluster.go
+++ b/pkg/controller/component/storaged_cluster.go
@@ -95,7 +95,7 @@ func (c *storagedCluster) syncStoragedWorkload(nc *v1alpha1.NebulaCluster) error
 	notExist := apierrors.IsNotFound(err)
 	oldWorkload := oldWorkloadTemp.DeepCopy()
 
-	cm, cmHash, e, err := c.syncStoragedConfigMap(nc.DeepCopy())
+	cm, cmHash, err := c.syncStoragedConfigMap(nc.DeepCopy())
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (c *storagedCluster) syncStoragedWorkload(nc *v1alpha1.NebulaCluster) error
 
 	if nc.StoragedComponent().IsReady() {
 		endpoints := nc.GetStoragedEndpoints(v1alpha1.StoragedPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations(), e); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update storaged cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 	}
@@ -195,7 +195,7 @@ func (c *storagedCluster) syncNebulaClusterStatus(
 	return syncComponentStatus(nc.StoragedComponent(), &nc.Status.Storaged.ComponentStatus, oldWorkload)
 }
 
-func (c *storagedCluster) syncStoragedConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, bool, error) {
+func (c *storagedCluster) syncStoragedConfigMap(nc *v1alpha1.NebulaCluster) (*corev1.ConfigMap, string, error) {
 	return syncConfigMap(
 		nc.StoragedComponent(),
 		c.clientSet.ConfigMap(),

--- a/pkg/util/maputil/map.go
+++ b/pkg/util/maputil/map.go
@@ -42,6 +42,37 @@ func AllKeysExist(first, second map[string]string) bool {
 	return true
 }
 
+func SymmetricDifference(first, second map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range first {
+		if _, ok := second[k]; !ok {
+			result[k] = v
+		}
+	}
+	for k, v := range second {
+		if _, ok := first[k]; !ok {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func IntersectionDifference(first, second map[string]string) (map[string]string, map[string]string) {
+	both := make(map[string]string)
+	diff := make(map[string]string)
+	for k, v := range first {
+		secv, ok := second[k]
+		if !ok {
+			diff[k] = v
+			continue
+		}
+		if v != secv {
+			both[k] = secv
+		}
+	}
+	return both, diff
+}
+
 func ResetMap(first, second map[string]string) {
 	for k := range first {
 		if second == nil {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-ent/issues/3038

#### Description:
When adding / updating dynamic flags, existing non-dynamic flags in the config map should not trigger restart of a pod.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


