### PR TITLE
fix dynamic flags

### DIFF
--- a/pkg/controller/component/graphd_cluster.go
+++ b/pkg/controller/component/graphd_cluster.go
@@ -136,7 +136,7 @@ func (c *graphdCluster) syncGraphdWorkload(nc *v1alpha1.NebulaCluster) error {
 
 	if nc.GraphdComponent().IsReady() {
 		endpoints := nc.GetGraphdEndpoints(v1alpha1.GraphdPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update graphd cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 	}

--- a/pkg/controller/component/helper.go
+++ b/pkg/controller/component/helper.go
@@ -19,7 +19,6 @@ package component
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -218,7 +217,7 @@ func staticFlags(config map[string]string) map[string]string {
 	return static
 }
 
-func updateDynamicFlags(endpoints []string, newAnnotations, oldAnnotations map[string]string) error {
+func updateDynamicFlags(endpoints []string, newAnnotations map[string]string) error {
 	newFlags := make(map[string]string)
 	newFlagsVal, ok := newAnnotations[annotation.AnnLastAppliedDynamicFlagsKey]
 	if ok {
@@ -226,23 +225,11 @@ func updateDynamicFlags(endpoints []string, newAnnotations, oldAnnotations map[s
 			return err
 		}
 	}
-	oldFlags := make(map[string]string)
-	oldFlagsVal, ok := oldAnnotations[annotation.AnnLastAppliedDynamicFlagsKey]
-	if ok {
-		if err := json.Unmarshal([]byte(oldFlagsVal), &oldFlags); err != nil {
-			return err
-		}
-	}
-	if reflect.DeepEqual(newFlags, oldFlags) {
+	if len(newFlags) == 0 {
 		return nil
 	}
-
-	updated, removed := maputil.IntersectionDifference(oldFlags, newFlags)
-	_, added := maputil.IntersectionDifference(newFlags, oldFlags)
-	maputil.ResetMap(removed, v1alpha1.DynamicFlags)
-	merged := maputil.MergeStringMaps(true, updated, added, removed)
-	klog.Infof("merged dynamic flags: %v", merged)
-	str, err := codec.Encode(merged)
+	klog.Infof("dynamic flags: %v", newFlags)
+	str, err := codec.Encode(newFlags)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/component/metad_cluster.go
+++ b/pkg/controller/component/metad_cluster.go
@@ -137,7 +137,7 @@ func (c *metadCluster) syncMetadWorkload(nc *v1alpha1.NebulaCluster) error {
 		}
 
 		endpoints := nc.GetMetadEndpoints(v1alpha1.MetadPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update metad cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 	}

--- a/pkg/controller/component/storaged_cluster.go
+++ b/pkg/controller/component/storaged_cluster.go
@@ -180,7 +180,7 @@ func (c *storagedCluster) syncStoragedWorkload(nc *v1alpha1.NebulaCluster) error
 
 	if nc.StoragedComponent().IsReady() {
 		endpoints := nc.GetStoragedEndpoints(v1alpha1.StoragedPortNameHTTP)
-		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations(), oldWorkload.GetAnnotations()); err != nil {
+		if err := updateDynamicFlags(endpoints, newWorkload.GetAnnotations()); err != nil {
 			return fmt.Errorf("update storaged cluster %s dynamic flags failed: %v", newWorkload.GetName(), err)
 		}
 

--- a/pkg/util/http/http.go
+++ b/pkg/util/http/http.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -44,7 +44,7 @@ func request(url, method string, jsonData []byte) ([]byte, error) {
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("io read error: %v", err)
 	}


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula-operator/issues/289
#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
creating cluster:
<img width="993" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/d9fa63f7-4d8a-47e2-bfcd-b430f00d40ad">

<img width="738" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/f02a5b5a-6d26-4f7f-981c-78b67c7330f8">

```
nebula-graph.io/last-applied-dynamic-flags: '{"accept_partial_success":"true","session_reclaim_interval_secs":"300","v":"2"}'
nebula-graph.io/last-applied-static-flags: '{"enable_http2_routing":"true","max_job_size":"36","max_sessions_per_ip_per_user":"10000","port":"8080","prioritize_intra_zone_reading":"true","redirect_stdout":"false","stderrthreshold":"0","stream_timeout_ms":"120000","sync_meta_when_use_space":"true"}'
```

updating config:
set dynamic flag v=2
<img width="971" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/e5bec097-b03a-40f1-9e6a-35b5bbf71f9f">
<img width="545" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/e3e433af-f3b8-46d8-a3c3-a3973e96f00e">

set flag accept_partial_success to false and set port to 8081
graphd pod restart again
<img width="1168" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/5825057d-b12e-4be4-a981-fa7d78d8fd85">

<img width="718" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/8e1e0cbd-4217-497a-bac3-279ce95fd7f0">

```
nebula-graph.io/last-applied-dynamic-flags: '{"accept_partial_success":"false","session_reclaim_interval_secs":"300","v":"2"}'
nebula-graph.io/last-applied-static-flags: '{"enable_http2_routing":"true","max_job_size":"36","max_sessions_per_ip_per_user":"10000","port":"8081","prioritize_intra_zone_reading":"true","redirect_stdout":"false","stderrthreshold":"0","stream_timeout_ms":"120000","sync_meta_when_use_space":"true"}'
```
scale graphd replicas to 2:
<img width="696" alt="image" src="https://github.com/vesoft-inc/nebula-operator/assets/4974026/8c42431d-b893-4a13-93e6-69cd71b09603">


