### PR TITLE
fix(raid-disk): fix scripts so they don't delete the data if raid disk is already mounted.

### DIFF
--- a/config/samples/raid-disks/eks-daemonset-raid-disks.yaml
+++ b/config/samples/raid-disks/eks-daemonset-raid-disks.yaml
@@ -150,10 +150,11 @@ spec:
                   exit 1
               else
                   echo "'${device}' is already mounted to '${mountpoint}'. Skipping mount"
+                  exit 0
               fi
-            else
-              echo "Mounting '${device}' at '${mountpoint}'"
-              mount -o discard,defaults "${device}" "${mountpoint}"
-              chmod a+w "${mountpoint}"
             fi
+            
+            echo "Mounting '${device}' at '${mountpoint}'"
+            mount -o discard,defaults "${device}" "${mountpoint}"
+            chmod a+w "${mountpoint}"
             rm -rf /mnt/disks/raid0/*

--- a/config/samples/raid-disks/gke-daemonset-raid-disks.yaml
+++ b/config/samples/raid-disks/gke-daemonset-raid-disks.yaml
@@ -66,10 +66,11 @@ spec:
                   exit 1
               else
                   echo "'${device}' is already mounted to '${mountpoint}'. Skipping mount"
+                  exit 0
               fi
-            else
-              echo "Mounting '${device}' at '${mountpoint}'"
-              mount -o discard,defaults "${device}" "${mountpoint}"
-              chmod a+w "${mountpoint}"
-            end
+            fi
+            
+            echo "Mounting '${device}' at '${mountpoint}'"
+            mount -o discard,defaults "${device}" "${mountpoint}"
+            chmod a+w "${mountpoint}"
             rm -rf /mnt/disks/raid0/*


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://nebula-graph.atlassian.net/browse/NGSR-234

#### Description:
Fix the raid test script so it doesn't delete the data on the raid disk and cause data loss if the raid disk is already mounted. This could happen in the current version if the `/tmp/startup-script.kubernetes.io` file gets deleted

#### Test Report:
https://nebula-graph.atlassian.net/wiki/spaces/TDEV/pages/971931673/EKS+Raid+Disk+Fix+Test+Report

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


