### PR TITLE
cherry-pick(raid-disk): fix scripts so they don't delete the data if raid disk is already mounted. (#576)

### DIFF
--- a/config/samples/raid-disks/eks-daemonset-raid-disks.yaml
+++ b/config/samples/raid-disks/eks-daemonset-raid-disks.yaml
@@ -139,6 +139,21 @@ spec:
 
             mountpoint=/mnt/disks/raid0
             mkdir -p "${mountpoint}"
+            
+            echo "Checking if device '${device}' is already mounted at '${mountpoint}'"
+            device_real=$(readlink -f "$device")
+            if mountpoint -q "$mountpoint"; then
+              mounted_device=$(findmnt -nro SOURCE --target "$mountpoint" | xargs readlink -f)
+
+              if [ "$mounted_device" != "$device_real" ]; then
+                  echo "error: '${mountpoint}' is already mounted to '${mounted_device}', unable to mount '${device}'."
+                  exit 1
+              else
+                  echo "'${device}' is already mounted to '${mountpoint}'. Skipping mount"
+                  exit 0
+              fi
+            fi
+            
             echo "Mounting '${device}' at '${mountpoint}'"
             mount -o discard,defaults "${device}" "${mountpoint}"
             chmod a+w "${mountpoint}"

--- a/config/samples/raid-disks/gke-daemonset-raid-disks.yaml
+++ b/config/samples/raid-disks/gke-daemonset-raid-disks.yaml
@@ -55,6 +55,21 @@ spec:
 
             mountpoint=/mnt/disks/raid0
             mkdir -p "${mountpoint}"
+
+            echo "Checking if device '${device}' is already mounted at '${mountpoint}'"
+            device_real=$(readlink -f "$device")
+            if mountpoint -q "$mountpoint"; then
+              mounted_device=$(findmnt -nro SOURCE --target "$mountpoint" | xargs readlink -f)
+
+              if [ "$mounted_device" != "$device_real" ]; then
+                  echo "error: '${mountpoint}' is already mounted to '${mounted_device}', unable to mount '${device}'."
+                  exit 1
+              else
+                  echo "'${device}' is already mounted to '${mountpoint}'. Skipping mount"
+                  exit 0
+              fi
+            fi
+            
             echo "Mounting '${device}' at '${mountpoint}'"
             mount -o discard,defaults "${device}" "${mountpoint}"
             chmod a+w "${mountpoint}"


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


