### PR TITLE
feat(nebulacluster_common): update missing resource limits 

### DIFF
--- a/apis/apps/v1alpha1/nebulacluster_common.go
+++ b/apis/apps/v1alpha1/nebulacluster_common.go
@@ -429,7 +429,10 @@ func generateLogContainer(c NebulaClusterComponent) corev1.Container {
 				corev1.ResourceCPU:    apiresource.MustParse("50m"),
 				corev1.ResourceMemory: apiresource.MustParse("50Mi"),
 			},
-			Limits: corev1.ResourceList{},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    apiresource.MustParse("200m"),
+				corev1.ResourceMemory: apiresource.MustParse("200Mi"),
+			},
 		},
 	}
 
@@ -595,6 +598,10 @@ cat /metadata/flags.json
 				corev1.ResourceCPU:    apiresource.MustParse("30m"),
 				corev1.ResourceMemory: apiresource.MustParse("30Mi"),
 			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    apiresource.MustParse("200m"),
+				corev1.ResourceMemory: apiresource.MustParse("200Mi"),
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -661,6 +668,10 @@ echo "export NODE_ZONE=${NODE_ZONE}" > /node/zone
 				corev1.ResourceCPU:    apiresource.MustParse("30m"),
 				corev1.ResourceMemory: apiresource.MustParse("30Mi"),
 			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    apiresource.MustParse("200m"),
+				corev1.ResourceMemory: apiresource.MustParse("200Mi"),
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -709,6 +720,10 @@ echo "${MOUNT_PATH}/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    apiresource.MustParse("30m"),
 				corev1.ResourceMemory: apiresource.MustParse("30Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    apiresource.MustParse("200m"),
+				corev1.ResourceMemory: apiresource.MustParse("200Mi"),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
@@ -833,6 +848,10 @@ done
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    apiresource.MustParse("50m"),
 				corev1.ResourceMemory: apiresource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    apiresource.MustParse("200m"),
+				corev1.ResourceMemory: apiresource.MustParse("200Mi"),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
Some workloads were missing CPU and memory resource limits, which could lead to unpredictable resource usage.

This ensures consistent resource allocation and prevents overconsumption.

With enabled quota for namespace:
https://kubernetes.io/docs/concepts/policy/resource-quotas/
it was not possible to deploy nebula-cluster because of lack of limits.
Quota requires that all resources are defined.

## How do you solve it?

Updated the missing resource limits by setting:
- CPU: `200m`
- Memory: `200Mi`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

I tested it and this limit is enough at least for one nebula cluster deployment.
