### PR TITLE
fix(memory-tracker): use containerized mode by default.

### DIFF
--- a/apis/apps/v1alpha1/template.go
+++ b/apis/apps/v1alpha1/template.go
@@ -140,6 +140,8 @@ const (
 ########## memory ##########
 # System memory high watermark ratio, cancel the memory checking when the ratio greater than 1.0
 --system_memory_high_watermark_ratio=0.8
+# use container memory limit
+--containerized=true
 
 ########## audit ##########
 # This variable is used to enable audit. The value can be 'true' or 'false'.
@@ -544,6 +546,8 @@ const (
 --memory_purge_enabled=true
 # memory background purge interval in seconds
 --memory_purge_interval_seconds=10
+# use container memory limit
+--containerized=true
 
 ########## SSL ##########
 # whether to enable ssl


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-operator/issues/540

#### Description:
1. If multiple pods are on the same host each pod will have its own independent cgroup path at /sys/fs/cgroup. 
2. Multiple containers within the same pod will share the same cgroup with the path still at /sys/fs/cgroup.

## How do you solve it?
Set the `--containerized` flag to true by default for both graphd and storaged.
Memory tracker log after setting:
<img width="1826" height="601" alt="Screenshot 2026-02-17 at 11 28 15 PM" src="https://github.com/user-attachments/assets/446ca119-8b74-4972-befc-85cd4790a77f" />


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
When the `--containerized` flag is set to true, the kubernetes container will automatically read the max memory from the correct file (/sys/fs/cgroup/memory.max) regardless of how many containers are on a pod. This has been tested.
